### PR TITLE
Add shuffle mode toggle for Next Task selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "./lib/formatDuration";
 import { getLiveDuration } from "./lib/getDuration";
+import { Shuffle } from "lucide-react";
 
 const makeDate = (mins: number) => Date.now() + mins * 60 * 1000;
 
@@ -33,6 +34,13 @@ function App() {
   const [isColorBreakdownOpen, setIsColorBreakdownOpen] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [pausedLong, setPausedLong] = useState(false);
+  const [shuffleMode, setShuffleMode] = useState(
+    () => localStorage.getItem("doroShuffleMode") === "true"
+  );
+
+  useEffect(() => {
+    localStorage.setItem("doroShuffleMode", String(shuffleMode));
+  }, [shuffleMode]);
   const taskManager = useTasks();
   const { isPaused, countdownRef, ...timer } = useTimer();
 
@@ -169,7 +177,7 @@ function App() {
   const handleContinue = () => {
     timer.pauseAudio();
     taskManager.logPause();
-    taskManager.nextTask();
+    taskManager.nextTask(shuffleMode);
     taskManager.logStart();
     setDate(makeDate(mins));
     timer.start();
@@ -233,6 +241,20 @@ function App() {
           onChange={(e) => setMins(Number(e.target.value) | 0)}
           className="w-20"
         />
+        <Button
+          variant={shuffleMode ? "default" : "outline"}
+          size="icon"
+          onClick={() => setShuffleMode((s) => !s)}
+          title={
+            shuffleMode
+              ? "Shuffle mode on: Next Task picks randomly"
+              : "Shuffle mode off: Next Task picks in order"
+          }
+          aria-pressed={shuffleMode}
+          aria-label="Toggle shuffle mode"
+        >
+          <Shuffle />
+        </Button>
         <span
           className="ml-auto text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
           onClick={(e) => {

--- a/src/hooks/useTasks.tsx
+++ b/src/hooks/useTasks.tsx
@@ -73,7 +73,8 @@ const useTasks = () => {
   const removeTask = (task: Task) =>
     dispatch({ type: "REMOVE_TASK", taskId: task.id });
 
-  const nextTask = () => dispatch({ type: "NEXT_TASK" });
+  const nextTask = (shuffle = false) =>
+    dispatch({ type: "NEXT_TASK", shuffle });
 
   const setStatus = (task: Task, status: Task["status"]) =>
     dispatch({ type: "SET_STATUS", taskId: task.id, status });

--- a/src/lib/tasksReducer.test.ts
+++ b/src/lib/tasksReducer.test.ts
@@ -1,7 +1,7 @@
 import tasksReducer from "./tasksReducer";
 import { createTask } from "./tasksReducer";
 import type Task from "../types/Task";
-import { expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 
 test("adds a new task to the list of tasks", () => {
   const tasks: Task[] = [];
@@ -460,4 +460,193 @@ test("MOVE_TASK with non-existent task returns unchanged state", () => {
   });
 
   expect(updated).toBe(tasks);
+});
+
+// NEXT_TASK shuffle mode tests
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("NEXT_TASK without shuffle picks first working task by order", () => {
+  const tasks: Task[] = [
+    { ...createTask("active"), status: "active", order: 1000 },
+    { ...createTask("first"), status: "working", order: 2000 },
+    { ...createTask("second"), status: "working", order: 3000 },
+    { ...createTask("third"), status: "working", order: 4000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: false });
+
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("first");
+});
+
+test("NEXT_TASK with shuffle picks a random working task (last index)", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.99);
+
+  const tasks: Task[] = [
+    { ...createTask("active"), status: "active", order: 1000 },
+    { ...createTask("first"), status: "working", order: 2000 },
+    { ...createTask("second"), status: "working", order: 3000 },
+    { ...createTask("third"), status: "working", order: 4000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // Math.floor(0.99 * 3) = 2 -> last task in the working pool ("third")
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("third");
+});
+
+test("NEXT_TASK with shuffle picks a random working task (middle index)", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+  const tasks: Task[] = [
+    { ...createTask("active"), status: "active", order: 1000 },
+    { ...createTask("first"), status: "working", order: 2000 },
+    { ...createTask("second"), status: "working", order: 3000 },
+    { ...createTask("third"), status: "working", order: 4000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // Math.floor(0.5 * 3) = 1 -> "second"
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("second");
+});
+
+test("NEXT_TASK with shuffle picks a random working task (first index)", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0);
+
+  const tasks: Task[] = [
+    { ...createTask("active"), status: "active", order: 1000 },
+    { ...createTask("first"), status: "working", order: 2000 },
+    { ...createTask("second"), status: "working", order: 3000 },
+    { ...createTask("third"), status: "working", order: 4000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // Math.floor(0 * 3) = 0 -> "first"
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("first");
+});
+
+test("NEXT_TASK with shuffle and only one other working task picks that one", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.7);
+
+  const tasks: Task[] = [
+    { ...createTask("active"), status: "active", order: 1000 },
+    { ...createTask("only one"), status: "working", order: 2000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("only one");
+
+  // Old active should now be in working
+  const oldActive = updated.find((t) => t.text === "active");
+  expect(oldActive?.status).toBe("working");
+});
+
+test("NEXT_TASK with shuffle and no other working tasks keeps state consistent", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+  const tasks: Task[] = [
+    { ...createTask("only active"), status: "active", order: 1000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // The previously active task gets moved to working (standard logic),
+  // and with no other candidates, no new active task is set.
+  const activeTasks = updated.filter((t) => t.status === "active");
+  expect(activeTasks.length).toBe(0);
+  const working = updated.filter((t) => t.status === "working");
+  expect(working.length).toBe(1);
+  expect(working[0].text).toBe("only active");
+});
+
+test("NEXT_TASK with shuffle when no task is currently active picks from working", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.99);
+
+  const tasks: Task[] = [
+    { ...createTask("first"), status: "working", order: 1000 },
+    { ...createTask("second"), status: "working", order: 2000 },
+    { ...createTask("third"), status: "working", order: 3000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // Math.floor(0.99 * 3) = 2 -> "third"
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("third");
+
+  // Only one active task in result
+  expect(updated.filter((t) => t.status === "active").length).toBe(1);
+});
+
+test("NEXT_TASK with shuffle moves old active to end of working bucket", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0);
+
+  const tasks: Task[] = [
+    { ...createTask("old active"), status: "active", order: 500 },
+    { ...createTask("working a"), status: "working", order: 2000 },
+    { ...createTask("working b"), status: "working", order: 3000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // Old active should now be working with order > max previous working order
+  const oldActive = updated.find((t) => t.text === "old active");
+  expect(oldActive?.status).toBe("working");
+  expect(oldActive?.order).toBeGreaterThan(3000);
+});
+
+test("NEXT_TASK with shuffle excludes the old active task from random pool", () => {
+  // If we included the old active task, Math.random = 0 could pick it back.
+  // This test ensures the pool only contains the other working tasks.
+  vi.spyOn(Math, "random").mockReturnValue(0);
+
+  const tasks: Task[] = [
+    { ...createTask("old active"), status: "active", order: 500 },
+    { ...createTask("candidate"), status: "working", order: 2000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // The only candidate should be activated — never the old active task
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("candidate");
+});
+
+test("NEXT_TASK with shuffle does not call Math.random when no candidates", () => {
+  const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+  const tasks: Task[] = [
+    { ...createTask("only active"), status: "active", order: 1000 },
+  ];
+
+  tasksReducer(tasks, { type: "NEXT_TASK", shuffle: true });
+
+  // Early return before Math.random is called
+  expect(randomSpy).not.toHaveBeenCalled();
+});
+
+test("NEXT_TASK with shuffle=undefined behaves like non-shuffle (first in order)", () => {
+  vi.spyOn(Math, "random").mockReturnValue(0.99);
+
+  const tasks: Task[] = [
+    { ...createTask("active"), status: "active", order: 1000 },
+    { ...createTask("first"), status: "working", order: 2000 },
+    { ...createTask("second"), status: "working", order: 3000 },
+  ];
+
+  const updated = tasksReducer(tasks, { type: "NEXT_TASK" });
+
+  // Should ignore Math.random and pick "first"
+  const activeNow = updated.find((t) => t.status === "active");
+  expect(activeNow?.text).toBe("first");
 });

--- a/src/lib/tasksReducer.ts
+++ b/src/lib/tasksReducer.ts
@@ -11,7 +11,7 @@ export type TasksAction =
       estimate?: number;
     }
   | { type: "REMOVE_TASK"; taskId: string }
-  | { type: "NEXT_TASK" }
+  | { type: "NEXT_TASK"; shuffle?: boolean }
   | { type: "SET_STATUS"; taskId: string; status: Task["status"] }
   | { type: "SET_NOTES"; taskId: string; text: string }
   | { type: "SET_TEXT"; taskId: string; text: string }
@@ -153,9 +153,14 @@ const tasksReducer = (state: Task[], action: TasksAction) => {
         return updatedState;
       }
 
-      // Activate the first working task
+      // Pick the next task: random if shuffle mode, else first in order
+      const pickIndex = action.shuffle
+        ? Math.floor(Math.random() * workingTasks.length)
+        : 0;
+      const nextActive = workingTasks[pickIndex];
+
       return updatedState.map((t) => {
-        if (t.id === workingTasks[0].id) {
+        if (t.id === nextActive.id) {
           return { ...t, status: "active" as const };
         }
         return t;


### PR DESCRIPTION
Adds a shuffle icon button next to the timer minutes input. When enabled, the "Next Task >>" button picks a random task from the working bucket instead of the first one in order. State persists across reloads via localStorage.

Thorough reducer tests cover: non-shuffle default, shuffle with first/ middle/last indices, single-candidate, zero-candidate, no-current-active, old-active exclusion from pool, and undefined shuffle flag fallback.

https://claude.ai/code/session_016mswHu97tmEgLAMKXSxcGf