### PR TITLE
Set imported task URL to the Todoist task's app URL

### DIFF
--- a/src/lib/todoist.test.ts
+++ b/src/lib/todoist.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { getTodoistTaskUrl, slugifyTodoistContent } from "./todoist";
+
+describe("slugifyTodoistContent", () => {
+  test("lowercases and replaces spaces with dashes", () => {
+    expect(slugifyTodoistContent("Hello World")).toBe("hello-world");
+  });
+
+  test("collapses multiple spaces and dashes", () => {
+    expect(slugifyTodoistContent("foo   bar---baz")).toBe("foo-bar-baz");
+  });
+
+  test("strips leading and trailing dashes", () => {
+    expect(slugifyTodoistContent("---foo bar---")).toBe("foo-bar");
+  });
+
+  test("removes punctuation", () => {
+    expect(slugifyTodoistContent("Buy milk, eggs, & bread!")).toBe(
+      "buy-milk-eggs-bread"
+    );
+  });
+
+  test("strips non-ASCII characters", () => {
+    expect(slugifyTodoistContent("café résumé")).toBe("cafe-resume");
+  });
+
+  test("strips emoji", () => {
+    expect(slugifyTodoistContent("ship it 🚀 today")).toBe("ship-it-today");
+  });
+
+  test("handles empty string", () => {
+    expect(slugifyTodoistContent("")).toBe("");
+  });
+
+  test("handles only-punctuation string", () => {
+    expect(slugifyTodoistContent("!!!")).toBe("");
+  });
+
+  test("preserves underscores and digits", () => {
+    expect(slugifyTodoistContent("task_2 v3")).toBe("task_2-v3");
+  });
+});
+
+describe("getTodoistTaskUrl", () => {
+  test("matches the user-provided example URL format", () => {
+    // From the user: https://app.todoist.com/app/task/ge-top-post-variant-model-shots-6gJgjp2fx2PwpRHC
+    expect(
+      getTodoistTaskUrl("6gJgjp2fx2PwpRHC", "ge top post variant model shots")
+    ).toBe(
+      "https://app.todoist.com/app/task/ge-top-post-variant-model-shots-6gJgjp2fx2PwpRHC"
+    );
+  });
+
+  test("builds URL with slug and id", () => {
+    expect(getTodoistTaskUrl("abc123", "Hello World")).toBe(
+      "https://app.todoist.com/app/task/hello-world-abc123"
+    );
+  });
+
+  test("falls back to just the id when content is empty", () => {
+    expect(getTodoistTaskUrl("abc123", "")).toBe(
+      "https://app.todoist.com/app/task/abc123"
+    );
+  });
+
+  test("falls back to just the id when content slugifies to empty", () => {
+    expect(getTodoistTaskUrl("abc123", "!!!")).toBe(
+      "https://app.todoist.com/app/task/abc123"
+    );
+  });
+});

--- a/src/lib/todoist.ts
+++ b/src/lib/todoist.ts
@@ -3,7 +3,6 @@ interface TodoistTask {
   content: string;
   description: string;
   priority: number; // 1 (normal) to 4 (urgent)
-  url: string;
   order: number;
 }
 
@@ -21,6 +20,32 @@ const PRIORITY_COLOR_MAP: Record<number, string> = {
   2: "#60a5fa", // medium -> blue
   1: "#9ca3af", // normal -> gray
 };
+
+const TODOIST_WEB_URI = "https://app.todoist.com/app";
+
+/**
+ * Slugify a string the same way the Todoist SDK does (Django-style):
+ * NFKD normalize, strip combining marks, drop non-ASCII, lowercase,
+ * remove non-word chars, collapse spaces/dashes to single dashes,
+ * trim leading/trailing dashes.
+ */
+export function slugifyTodoistContent(value: string): string {
+  let result = value.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+  result = result.replace(/[^\x20-\x7E]/g, "");
+  result = result.toLowerCase().replace(/[^\w\s-]/g, "");
+  result = result.replace(/[-\s]+/g, "-");
+  return result.replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Build a Todoist task URL from its id and content, matching the format
+ * the Todoist SDK generates: https://app.todoist.com/app/task/<slug>-<id>
+ */
+export function getTodoistTaskUrl(id: string, content: string): string {
+  const slug = content ? slugifyTodoistContent(content) : "";
+  const path = slug ? `${slug}-${id}` : id;
+  return `${TODOIST_WEB_URI}/task/${path}`;
+}
 
 export async function fetchTodaysTasks(
   token: string
@@ -41,7 +66,7 @@ export async function fetchTodaysTasks(
     .map((t) => ({
       text: t.content,
       notes: t.description,
-      url: t.url,
+      url: getTodoistTaskUrl(t.id, t.content),
       color: PRIORITY_COLOR_MAP[t.priority] ?? "#9ca3af",
       todoistId: t.id,
     }));


### PR DESCRIPTION
The v1 Todoist API does not return a task URL field — the official SDK constructs it client-side from the task id and content. Port the SDK's URL builder (slug + id) so imported tasks link back to the task in Todoist's web app.

Adds slugifyTodoistContent and getTodoistTaskUrl helpers with tests covering punctuation, non-ASCII, emoji, empty content fallback, and verification against the user-provided example URL format.

https://claude.ai/code/session_016mswHu97tmEgLAMKXSxcGf