### PR TITLE
Add optional label filter to Todoist import

### DIFF
--- a/api/todoist.ts
+++ b/api/todoist.ts
@@ -10,9 +10,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(401).json({ error: "Missing token parameter" });
   }
 
+  const label = typeof req.query.label === "string" ? req.query.label.trim() : "";
+
   try {
     const url = new URL("https://api.todoist.com/api/v1/tasks/filter");
-    url.searchParams.set("query", "today | overdue");
+    // Label names in Todoist filter syntax are prefixed with @. Escape with
+    // backslash for any special chars; conservatively strip whitespace/@ from
+    // user input so the filter parses.
+    const safeLabel = label.replace(/[^\w-]/g, "");
+    const query = safeLabel
+      ? `(today | overdue) & @${safeLabel}`
+      : "today | overdue";
+    url.searchParams.set("query", query);
 
     const response = await fetch(url.toString(), {
       headers: { Authorization: `Bearer ${token}` },

--- a/src/components/TodoistImport.tsx
+++ b/src/components/TodoistImport.tsx
@@ -6,6 +6,8 @@ import {
   getTodoistToken,
   setTodoistToken,
   clearTodoistToken,
+  getTodoistLabel,
+  setTodoistLabel,
   type ImportableTask,
 } from "../lib/todoist";
 
@@ -16,8 +18,14 @@ interface TodoistImportProps {
 function TodoistImport({ onImport }: TodoistImportProps) {
   const [token, setToken] = useState(getTodoistToken);
   const [tokenInput, setTokenInput] = useState("");
+  const [label, setLabel] = useState(getTodoistLabel);
   const [loading, setLoading] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
+
+  const handleLabelChange = (value: string) => {
+    setLabel(value);
+    setTodoistLabel(value);
+  };
 
   const handleSaveToken = () => {
     const trimmed = tokenInput.trim();
@@ -39,9 +47,13 @@ function TodoistImport({ onImport }: TodoistImportProps) {
     setLoading(true);
     setStatus(null);
     try {
-      const tasks = await fetchTodaysTasks(token);
+      const tasks = await fetchTodaysTasks(token, label);
       if (tasks.length === 0) {
-        setStatus("No tasks due today");
+        setStatus(
+          label.trim()
+            ? `No tasks due today with label "${label.trim()}"`
+            : "No tasks due today"
+        );
       } else {
         onImport(tasks);
         setStatus(`Imported ${tasks.length} task${tasks.length === 1 ? "" : "s"}`);
@@ -87,6 +99,13 @@ function TodoistImport({ onImport }: TodoistImportProps) {
       <Button variant="outline" onClick={handleImport} disabled={loading}>
         {loading ? "Importing..." : "Import from Todoist"}
       </Button>
+      <Input
+        value={label}
+        onChange={(e) => handleLabelChange(e.target.value)}
+        onClick={(e) => e.stopPropagation()}
+        placeholder="label filter (optional)"
+        className="w-44 h-8 text-sm"
+      />
       <button
         onClick={handleDisconnect}
         className="text-xs text-muted-foreground hover:text-foreground underline"

--- a/src/lib/todoist.ts
+++ b/src/lib/todoist.ts
@@ -48,11 +48,14 @@ export function getTodoistTaskUrl(id: string, content: string): string {
 }
 
 export async function fetchTodaysTasks(
-  token: string
+  token: string,
+  label?: string
 ): Promise<ImportableTask[]> {
-  const response = await fetch(
-    `/api/todoist?token=${encodeURIComponent(token)}`
-  );
+  const params = new URLSearchParams({ token });
+  if (label?.trim()) {
+    params.set("label", label.trim());
+  }
+  const response = await fetch(`/api/todoist?${params.toString()}`);
 
   if (!response.ok) {
     if (response.status === 401) throw new Error("Invalid Todoist API token");
@@ -82,4 +85,12 @@ export function setTodoistToken(token: string): void {
 
 export function clearTodoistToken(): void {
   localStorage.removeItem("doroTodoistToken");
+}
+
+export function getTodoistLabel(): string {
+  return localStorage.getItem("doroTodoistLabel") ?? "";
+}
+
+export function setTodoistLabel(label: string): void {
+  localStorage.setItem("doroTodoistLabel", label);
 }


### PR DESCRIPTION
Adds a text input next to the "Import from Todoist" button. When empty, import behavior is unchanged (all today's + overdue tasks). When a label name is entered, the import filters to only tasks with that label using Todoist's filter syntax: (today | overdue) & @<label>.

The label is persisted in localStorage (doroTodoistLabel) so it survives reloads and doesn't need to be re-entered each day. Label input is sanitized server-side (strips non-word chars) before being injected into the filter query.

https://claude.ai/code/session_016mswHu97tmEgLAMKXSxcGf