### PR TITLE
Add line move functionality with Alt+Arrow keys in textareas

### DIFF
--- a/src/components/ActiveTaskView.tsx
+++ b/src/components/ActiveTaskView.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { formatEstimate, parseTime } from "@/lib/parseTime";
 import { getLiveDuration } from "@/lib/getDuration";
 import { formatDuration } from "@/lib/formatDuration";
+import { handleLineMoveKeyDown } from "@/lib/moveLine";
 import { cn } from "@/lib/utils";
 import { ExternalLink } from "lucide-react";
 
@@ -188,6 +189,10 @@ function ActiveTaskView({
       <Textarea
         value={task.notes}
         onChange={(e) => onNotesChange(task, e.target.value)}
+        onKeyDown={(e) => {
+          const moved = handleLineMoveKeyDown(e);
+          if (moved !== null) onNotesChange(task, moved);
+        }}
         placeholder="Notes..."
         className="min-h-[80px] resize-y bg-white"
       />

--- a/src/components/TasksView.tsx
+++ b/src/components/TasksView.tsx
@@ -4,6 +4,7 @@ import { formatDuration } from "../lib/formatDuration";
 import { parseTime, formatEstimate } from "../lib/parseTime";
 import { getAccomplishable, type AccomplishableResult } from "../lib/getAccomplishable";
 import { calculateDropOrder } from "../lib/calculateDropOrder";
+import { handleLineMoveKeyDown } from "../lib/moveLine";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -876,6 +877,10 @@ const TaskItem = ({
           <Textarea
             value={task.notes}
             onChange={(e) => manager.setNotes(task, e.target.value)}
+            onKeyDown={(e) => {
+              const moved = handleLineMoveKeyDown(e);
+              if (moved !== null) manager.setNotes(task, moved);
+            }}
             onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
             placeholder="Notes..."

--- a/src/lib/moveLine.test.ts
+++ b/src/lib/moveLine.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { moveLine } from "./moveLine";
+
+const text = "one\ntwo\nthree";
+
+describe("moveLine", () => {
+  it("moves the cursor line up", () => {
+    // cursor on "two" (offset 5)
+    const result = moveLine(text, 5, 5, -1);
+    expect(result).toEqual({
+      value: "two\none\nthree",
+      selectionStart: 1,
+      selectionEnd: 1,
+    });
+  });
+
+  it("moves the cursor line down", () => {
+    // cursor on "two" (offset 5)
+    const result = moveLine(text, 5, 5, 1);
+    expect(result).toEqual({
+      value: "one\nthree\ntwo",
+      selectionStart: 11,
+      selectionEnd: 11,
+    });
+  });
+
+  it("returns null when moving the first line up", () => {
+    expect(moveLine(text, 2, 2, -1)).toBeNull();
+  });
+
+  it("returns null when moving the last line down", () => {
+    expect(moveLine(text, 10, 10, 1)).toBeNull();
+  });
+
+  it("moves a multi-line selection as a block", () => {
+    // selection spans "two" and "three" in "one\ntwo\nthree\nfour"
+    const result = moveLine("one\ntwo\nthree\nfour", 5, 10, -1);
+    expect(result).toEqual({
+      value: "two\nthree\none\nfour",
+      selectionStart: 1,
+      selectionEnd: 6,
+    });
+  });
+
+  it("does not drag along a line the selection only touches at offset 0", () => {
+    // selection from "two" to the very start of "three"
+    const result = moveLine(text, 4, 8, 1);
+    expect(result).toEqual({
+      value: "one\nthree\ntwo",
+      selectionStart: 10,
+      selectionEnd: 14,
+    });
+  });
+
+  it("handles empty lines", () => {
+    const result = moveLine("one\n\ntwo", 4, 4, 1);
+    expect(result).toEqual({
+      value: "one\ntwo\n",
+      selectionStart: 8,
+      selectionEnd: 8,
+    });
+  });
+
+  it("keeps the caret column when moving past a shorter line", () => {
+    // cursor at end of "three" (offset 13), moving up past "two"
+    const result = moveLine(text, 13, 13, -1);
+    expect(result).toEqual({
+      value: "one\nthree\ntwo",
+      selectionStart: 9,
+      selectionEnd: 9,
+    });
+  });
+
+  it("returns null for single-line text", () => {
+    expect(moveLine("only", 2, 2, -1)).toBeNull();
+    expect(moveLine("only", 2, 2, 1)).toBeNull();
+  });
+});

--- a/src/lib/moveLine.ts
+++ b/src/lib/moveLine.ts
@@ -1,0 +1,94 @@
+import type { KeyboardEvent } from "react";
+
+export interface MoveLineResult {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+/**
+ * Swap the line(s) covered by the selection with the adjacent line
+ * above (direction -1) or below (direction 1). Returns null when the
+ * selection is already at the edge and can't move.
+ */
+export function moveLine(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  direction: -1 | 1
+): MoveLineResult | null {
+  const lines = value.split("\n");
+
+  const lineStarts: number[] = [0];
+  for (let i = 0; i < lines.length - 1; i++) {
+    lineStarts.push(lineStarts[i] + lines[i].length + 1);
+  }
+
+  const lineIndexAt = (offset: number) => {
+    let index = 0;
+    while (index + 1 < lineStarts.length && lineStarts[index + 1] <= offset) {
+      index++;
+    }
+    return index;
+  };
+
+  const startLine = lineIndexAt(selectionStart);
+  let endLine = lineIndexAt(selectionEnd);
+  // A selection ending at the very start of a line doesn't include that line
+  if (endLine > startLine && selectionEnd === lineStarts[endLine]) {
+    endLine--;
+  }
+
+  if (direction === -1 && startLine === 0) return null;
+  if (direction === 1 && endLine === lines.length - 1) return null;
+
+  const newLines = [...lines];
+  let delta: number;
+  if (direction === -1) {
+    const [moved] = newLines.splice(startLine - 1, 1);
+    newLines.splice(endLine, 0, moved);
+    delta = -(moved.length + 1);
+  } else {
+    const [moved] = newLines.splice(endLine + 1, 1);
+    newLines.splice(startLine, 0, moved);
+    delta = moved.length + 1;
+  }
+
+  return {
+    value: newLines.join("\n"),
+    selectionStart: selectionStart + delta,
+    selectionEnd: selectionEnd + delta,
+  };
+}
+
+/**
+ * Handle alt+ArrowUp / alt+ArrowDown in a textarea by moving the
+ * selected line(s). Returns the new value, or null if the event isn't a
+ * line-move shortcut or the lines can't move. Restores the caret after
+ * the controlled re-render.
+ */
+export function handleLineMoveKeyDown(
+  e: KeyboardEvent<HTMLTextAreaElement>
+): string | null {
+  if (
+    !e.altKey ||
+    e.ctrlKey ||
+    e.metaKey ||
+    (e.key !== "ArrowUp" && e.key !== "ArrowDown")
+  ) {
+    return null;
+  }
+  e.preventDefault();
+  const el = e.currentTarget;
+  const result = moveLine(
+    el.value,
+    el.selectionStart,
+    el.selectionEnd,
+    e.key === "ArrowUp" ? -1 : 1
+  );
+  if (!result) return null;
+  requestAnimationFrame(() => {
+    el.setSelectionRange(result.selectionStart, result.selectionEnd);
+  });
+  return result.value;
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to move lines up and down in textarea fields using Alt+ArrowUp and Alt+ArrowDown keyboard shortcuts, similar to functionality found in popular code editors like VS Code.

## Key Changes
- **New `moveLine` utility** (`src/lib/moveLine.ts`): Core logic for moving line(s) within text
  - Handles single-line and multi-line selections
  - Correctly calculates line boundaries and selection offsets
  - Returns null when lines can't move (already at edge)
  - Preserves caret position relative to line content when moving past shorter lines

- **New `handleLineMoveKeyDown` handler**: Keyboard event handler for Alt+Arrow shortcuts
  - Detects Alt+ArrowUp/ArrowDown key combinations
  - Prevents default browser behavior
  - Restores selection range after DOM update using `requestAnimationFrame`

- **Comprehensive test suite** (`src/lib/moveLine.test.ts`): 8 test cases covering:
  - Moving lines up and down
  - Edge cases (first/last line, empty lines)
  - Multi-line selections
  - Selection boundary handling
  - Caret column preservation

- **Integration in textarea components**:
  - `ActiveTaskView.tsx`: Added line move support to task notes textarea
  - `TasksView.tsx`: Added line move support to task notes textarea in task items

## Implementation Details
- The `moveLine` function calculates line start positions to map character offsets to line indices
- Selection ending exactly at a line start is treated as not including that line
- Delta calculation accounts for newline characters (length + 1) when computing new selection positions
- Uses `requestAnimationFrame` to ensure selection range is restored after React re-renders the textarea value

https://claude.ai/code/session_011ii6ZQTsnc3usQPSKrig8h