### PR TITLE
Add color-based time goals feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import TasksView from "./components/TasksView";
 import AddTaskModal from "./components/AddTaskModal";
 import SwitchTaskModal from "./components/SwitchTaskModal";
 import WorkflowyMode from "./components/WorkflowyMode";
+import ColorGoals from "./components/ColorGoals";
 import useTasks from "./hooks/useTasks";
 import useTimer from "./hooks/useTimer";
 import type Task from "./types/Task";
@@ -15,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { formatDuration } from "./lib/formatDuration";
 import { getLiveDuration } from "./lib/getDuration";
 import { Shuffle } from "lucide-react";
+import { DEFAULT_COLOR, colorLabel } from "./lib/taskColors";
 
 const makeDate = (mins: number) => Date.now() + mins * 60 * 1000;
 
@@ -28,16 +30,6 @@ const requestNotificationPermission = () => {
   if ("Notification" in window && Notification.permission === "default") {
     Notification.requestPermission();
   }
-};
-
-const TASK_COLORS: Record<string, string> = {
-  "#9ca3af": "Gray",
-  "#f87171": "Red",
-  "#fb923c": "Orange",
-  "#facc15": "Yellow",
-  "#4ade80": "Green",
-  "#60a5fa": "Blue",
-  "#c084fc": "Purple",
 };
 
 const DONUT_RADIUS = 40;
@@ -91,7 +83,7 @@ function ColorDonut({
               transform="rotate(-90 70 70)"
             >
               <title>
-                {`${TASK_COLORS[color] || color}: ${formatDuration(
+                {`${colorLabel(color)}: ${formatDuration(
                   duration
                 )} (${Math.round(frac * 100)}%)`}
               </title>
@@ -197,13 +189,18 @@ function App() {
     for (const task of taskManager.tasks) {
       const dur = getTaskDuration(task);
       if (dur <= 0) continue;
-      const color = task.color || "#9ca3af";
+      const color = task.color || DEFAULT_COLOR;
       map.set(color, (map.get(color) || 0) + dur);
     }
     // Sort by duration descending
     return [...map.entries()].sort((a, b) => b[1] - a[1]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [taskManager.tasks, isPaused, tick]);
+
+  const progressByColor = useMemo(
+    () => Object.fromEntries(colorBreakdown),
+    [colorBreakdown]
+  );
 
   // Start pulsing the paused indicator after 2 minutes
   useEffect(() => {
@@ -393,6 +390,11 @@ function App() {
       className="w-full max-w-2xl mx-auto px-4 py-8"
       onClick={() => setSelectedTaskId(null)}
     >
+      <ColorGoals
+        progress={progressByColor}
+        isPaused={isPaused}
+        activeColor={activeTask ? activeTask.color || DEFAULT_COLOR : undefined}
+      />
       <div className="flex items-center gap-2 mb-4">
         <Button onClick={() => setIsAddModalOpen(true)}>+ Add Task</Button>
         <Input
@@ -553,7 +555,7 @@ function App() {
                       style={{ backgroundColor: color }}
                     />
                     <span className="text-sm flex-1">
-                      {TASK_COLORS[color] || color}
+                      {colorLabel(color)}
                     </span>
                     <span className="text-sm font-medium">
                       {formatDuration(duration)}

--- a/src/components/ColorGoals.tsx
+++ b/src/components/ColorGoals.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useState } from "react";
+import { Minus, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { formatDuration } from "@/lib/formatDuration";
+import { parseTime } from "@/lib/parseTime";
+import { TASK_COLORS, colorLabel } from "@/lib/taskColors";
+import {
+  goalBarFractions,
+  loadGoals,
+  type ColorGoal,
+} from "@/lib/colorGoals";
+
+function GoalBar({
+  goal,
+  worked,
+  onRemove,
+}: {
+  goal: ColorGoal;
+  worked: number;
+  onRemove?: () => void;
+}) {
+  const { fill, over } = goalBarFractions(worked, goal.target);
+  const overMs = Math.max(worked - goal.target, 0);
+  return (
+    <div className="group flex items-center gap-2">
+      <div className="relative flex-1 h-6 rounded-md bg-muted overflow-hidden">
+        <div
+          className="absolute inset-y-0 left-0"
+          style={{ width: `${fill * 100}%`, backgroundColor: goal.color }}
+        />
+        {over > 0 && (
+          <div
+            className="absolute inset-y-0 right-0 bg-red-500"
+            style={{ width: `${over * 100}%` }}
+            title={`${formatDuration(overMs)} over goal`}
+          />
+        )}
+        <div className="absolute inset-0 flex items-center justify-between px-2 text-xs font-medium text-gray-900">
+          <span>{colorLabel(goal.color)}</span>
+          <span>
+            {formatDuration(worked)} / {formatDuration(goal.target)}
+            {overMs > 0 && (
+              <span className="font-bold text-red-950">
+                {" "}
+                +{formatDuration(overMs)}
+              </span>
+            )}
+          </span>
+        </div>
+      </div>
+      {onRemove ? (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={onRemove}
+          aria-label={`Remove ${colorLabel(goal.color)} goal`}
+        >
+          <Minus />
+        </Button>
+      ) : (
+        <div className="w-6 shrink-0" />
+      )}
+    </div>
+  );
+}
+
+export default function ColorGoals({
+  progress,
+  isPaused,
+  activeColor,
+}: {
+  progress: Record<string, number>;
+  isPaused: boolean;
+  activeColor?: string;
+}) {
+  const [goals, setGoals] = useState<ColorGoal[]>(loadGoals);
+  const [isAdding, setIsAdding] = useState(false);
+  const [newColor, setNewColor] = useState<string | null>(null);
+  const [timeInput, setTimeInput] = useState("");
+
+  useEffect(() => {
+    localStorage.setItem("doroColorGoals", JSON.stringify(goals));
+  }, [goals]);
+
+  // Only one goal per color, so offer just the colors without one
+  const availableColors = TASK_COLORS.filter(
+    (c) => !goals.some((g) => g.color === c.hex)
+  );
+
+  // While the timer runs, only the active task's color matters
+  const visibleGoals = isPaused
+    ? goals
+    : goals.filter((g) => g.color === activeColor);
+
+  if (visibleGoals.length === 0 && !isPaused) return null;
+
+  const parsedTime = parseTime(timeInput);
+  const canAdd = newColor !== null && parsedTime !== null && parsedTime > 0;
+
+  const addGoal = () => {
+    if (!canAdd || newColor === null || parsedTime === null) return;
+    setGoals([...goals, { color: newColor, target: parsedTime }]);
+    setIsAdding(false);
+    setNewColor(null);
+    setTimeInput("");
+  };
+
+  const cancelAdd = () => {
+    setIsAdding(false);
+    setNewColor(null);
+    setTimeInput("");
+  };
+
+  return (
+    <div className="group/goals mb-4 space-y-1">
+      {visibleGoals.map((goal) => (
+        <GoalBar
+          key={goal.color}
+          goal={goal}
+          worked={progress[goal.color] || 0}
+          onRemove={
+            isPaused
+              ? () => setGoals(goals.filter((g) => g.color !== goal.color))
+              : undefined
+          }
+        />
+      ))}
+      {isPaused &&
+        (isAdding ? (
+          <div
+            className="flex items-center gap-2 flex-wrap"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-1.5">
+              {availableColors.map((c) => (
+                <button
+                  key={c.hex}
+                  type="button"
+                  className={cn(
+                    "w-5 h-5 rounded-full transition-transform hover:scale-110",
+                    newColor === c.hex && "ring-2 ring-ring ring-offset-2"
+                  )}
+                  style={{ backgroundColor: c.hex }}
+                  onClick={() => setNewColor(c.hex)}
+                  aria-label={colorLabel(c.hex)}
+                  aria-pressed={newColor === c.hex}
+                />
+              ))}
+            </div>
+            <Input
+              autoFocus
+              value={timeInput}
+              onChange={(e) => setTimeInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") addGoal();
+                if (e.key === "Escape") cancelAdd();
+              }}
+              placeholder="1h 30m"
+              className="w-24 h-8"
+              aria-label="Goal time"
+            />
+            <Button size="sm" onClick={addGoal} disabled={!canAdd}>
+              Add
+            </Button>
+            <Button size="sm" variant="ghost" onClick={cancelAdd}>
+              Cancel
+            </Button>
+          </div>
+        ) : (
+          availableColors.length > 0 && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-6 w-6 text-muted-foreground",
+                // Keep the button discoverable when there's nothing to hover
+                goals.length > 0 &&
+                  "opacity-0 group-hover/goals:opacity-100 focus-visible:opacity-100 transition-opacity"
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsAdding(true);
+              }}
+              aria-label="Add color goal"
+              title="Add a goal for a color"
+            >
+              <Plus />
+            </Button>
+          )
+        ))}
+    </div>
+  );
+}

--- a/src/components/TasksView.tsx
+++ b/src/components/TasksView.tsx
@@ -39,16 +39,7 @@ import {
 import type { DraggableSyntheticListeners, DraggableAttributes } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 
-// Task colors (Tailwind 400-level)
-const TASK_COLORS = [
-  { name: "gray", hex: "#9ca3af" },
-  { name: "red", hex: "#f87171" },
-  { name: "orange", hex: "#fb923c" },
-  { name: "yellow", hex: "#facc15" },
-  { name: "green", hex: "#4ade80" },
-  { name: "blue", hex: "#60a5fa" },
-  { name: "purple", hex: "#c084fc" },
-];
+import { TASK_COLORS } from "@/lib/taskColors";
 
 interface TaskManager {
   tasks: Task[];

--- a/src/lib/colorGoals.test.ts
+++ b/src/lib/colorGoals.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { goalBarFractions } from "./colorGoals";
+
+const HOUR = 60 * 60 * 1000;
+
+describe("goalBarFractions", () => {
+  it("is empty with no time worked", () => {
+    expect(goalBarFractions(0, HOUR)).toEqual({ fill: 0, over: 0 });
+  });
+
+  it("fills proportionally under the goal", () => {
+    expect(goalBarFractions(HOUR / 2, HOUR)).toEqual({ fill: 0.5, over: 0 });
+  });
+
+  it("fills exactly at the goal with no overage", () => {
+    expect(goalBarFractions(HOUR, HOUR)).toEqual({ fill: 1, over: 0 });
+  });
+
+  it("caps fill at 1 and shows overage scaled to the goal", () => {
+    expect(goalBarFractions(1.5 * HOUR, HOUR)).toEqual({ fill: 1, over: 0.5 });
+  });
+
+  it("caps overage at the full bar once a whole goal over", () => {
+    expect(goalBarFractions(3 * HOUR, HOUR)).toEqual({ fill: 1, over: 1 });
+  });
+
+  it("handles a zero or negative target without dividing by zero", () => {
+    expect(goalBarFractions(HOUR, 0)).toEqual({ fill: 0, over: 0 });
+    expect(goalBarFractions(HOUR, -1)).toEqual({ fill: 0, over: 0 });
+  });
+
+  it("clamps negative worked time to zero", () => {
+    expect(goalBarFractions(-HOUR, HOUR)).toEqual({ fill: 0, over: 0 });
+  });
+});

--- a/src/lib/colorGoals.ts
+++ b/src/lib/colorGoals.ts
@@ -1,0 +1,37 @@
+export interface ColorGoal {
+  color: string;
+  target: number; // ms
+}
+
+/**
+ * Fractions for rendering a goal bar of fixed length. `fill` is how much of
+ * the bar shows the goal color; `over` is how much of the right end turns
+ * red once the goal is exceeded. The bar never grows past its full length,
+ * so the red portion is scaled to the goal and caps at the whole bar once
+ * you're a full goal's worth over (2x the target).
+ */
+export const goalBarFractions = (
+  worked: number,
+  target: number
+): { fill: number; over: number } => {
+  if (target <= 0) return { fill: 0, over: 0 };
+  const fill = Math.min(Math.max(worked, 0) / target, 1);
+  const over = worked > target ? Math.min((worked - target) / target, 1) : 0;
+  return { fill, over };
+};
+
+export const loadGoals = (): ColorGoal[] => {
+  try {
+    const parsed = JSON.parse(localStorage.getItem("doroColorGoals") || "[]");
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (g): g is ColorGoal =>
+        g != null &&
+        typeof g.color === "string" &&
+        typeof g.target === "number" &&
+        g.target > 0
+    );
+  } catch {
+    return [];
+  }
+};

--- a/src/lib/taskColors.ts
+++ b/src/lib/taskColors.ts
@@ -1,0 +1,20 @@
+// Task colors (Tailwind 400-level). The hex values carry identity across
+// the app — tasks store the hex directly.
+export const TASK_COLORS = [
+  { name: "gray", hex: "#9ca3af" },
+  { name: "red", hex: "#f87171" },
+  { name: "orange", hex: "#fb923c" },
+  { name: "yellow", hex: "#facc15" },
+  { name: "green", hex: "#4ade80" },
+  { name: "blue", hex: "#60a5fa" },
+  { name: "purple", hex: "#c084fc" },
+];
+
+// Tasks with no color set are treated as gray everywhere time is
+// aggregated by color.
+export const DEFAULT_COLOR = "#9ca3af";
+
+export const colorLabel = (hex: string): string => {
+  const found = TASK_COLORS.find((c) => c.hex === hex);
+  return found ? found.name.charAt(0).toUpperCase() + found.name.slice(1) : hex;
+};


### PR DESCRIPTION
## Summary
This PR introduces a new color-based time goals feature that allows users to set target durations for specific task colors and track progress against those goals with visual progress bars.

## Key Changes

- **New `ColorGoals` component** (`src/components/ColorGoals.tsx`): Displays progress bars for each color goal, showing time worked vs. target with visual overflow indication when goals are exceeded. Includes UI for adding/removing goals when the timer is paused.

- **New `colorGoals` library** (`src/lib/colorGoals.ts`): 
  - `ColorGoal` interface for storing color and target duration
  - `goalBarFractions()` utility to calculate fill and overflow percentages for rendering progress bars
  - `loadGoals()` function to persist goals in localStorage with validation

- **New `taskColors` library** (`src/lib/taskColors.ts`): Extracted color definitions and utilities into a shared module:
  - `TASK_COLORS` array with name/hex pairs
  - `DEFAULT_COLOR` constant for tasks without explicit color
  - `colorLabel()` function to convert hex codes to human-readable names

- **Updated `App.tsx`**: 
  - Integrated `ColorGoals` component into main layout
  - Added `progressByColor` memo to track time worked per color
  - Replaced inline color map with imported `TASK_COLORS` and `DEFAULT_COLOR`

- **Updated `TasksView.tsx`**: Replaced inline color definitions with import from `taskColors` library

- **Comprehensive tests** (`src/lib/colorGoals.test.ts`): Full test coverage for `goalBarFractions()` including edge cases (zero targets, negative values, overage capping)

## Notable Implementation Details

- Goals are only visible when the timer is paused (except the active color's goal shows while running)
- Visual overflow indicator (red bar) scales to the goal amount and caps at 100% when 2x over
- Only one goal per color; color picker only shows available colors
- Goals persist to localStorage and validate on load
- Time input supports flexible formats via existing `parseTime()` utility

https://claude.ai/code/session_01HwRrg7FGA5rXsnFCA3yrBY