### PR TITLE
Redesign goal bar overflow visualization

### DIFF
--- a/src/components/ColorGoals.tsx
+++ b/src/components/ColorGoals.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "@/lib/formatDuration";
 import { parseTime } from "@/lib/parseTime";
-import { TASK_COLORS, colorLabel } from "@/lib/taskColors";
+import { TASK_COLORS, colorLabel, darkenColor } from "@/lib/taskColors";
 import {
   goalBarFractions,
   loadGoals,
@@ -32,8 +32,11 @@ function GoalBar({
         />
         {over > 0 && (
           <div
-            className="absolute inset-y-0 right-0 bg-red-500"
-            style={{ width: `${over * 100}%` }}
+            className="absolute inset-y-0 right-0"
+            style={{
+              width: `${over * 100}%`,
+              backgroundColor: darkenColor(goal.color),
+            }}
             title={`${formatDuration(overMs)} over goal`}
           />
         )}

--- a/src/lib/colorGoals.test.ts
+++ b/src/lib/colorGoals.test.ts
@@ -16,12 +16,19 @@ describe("goalBarFractions", () => {
     expect(goalBarFractions(HOUR, HOUR)).toEqual({ fill: 1, over: 0 });
   });
 
-  it("caps fill at 1 and shows overage scaled to the goal", () => {
-    expect(goalBarFractions(1.5 * HOUR, HOUR)).toEqual({ fill: 1, over: 0.5 });
+  it("splits the bar as shares of accumulated time once over the goal", () => {
+    expect(goalBarFractions(1.5 * HOUR, HOUR)).toEqual({
+      fill: 1 / 1.5,
+      over: 0.5 / 1.5,
+    });
+    expect(goalBarFractions(2 * HOUR, HOUR)).toEqual({ fill: 0.5, over: 0.5 });
   });
 
-  it("caps overage at the full bar once a whole goal over", () => {
-    expect(goalBarFractions(3 * HOUR, HOUR)).toEqual({ fill: 1, over: 1 });
+  it("never lets overage take the whole bar", () => {
+    const { fill, over } = goalBarFractions(10 * HOUR, HOUR);
+    expect(fill).toBeCloseTo(0.1);
+    expect(over).toBeCloseTo(0.9);
+    expect(fill + over).toBeCloseTo(1);
   });
 
   it("handles a zero or negative target without dividing by zero", () => {

--- a/src/lib/colorGoals.ts
+++ b/src/lib/colorGoals.ts
@@ -4,20 +4,21 @@ export interface ColorGoal {
 }
 
 /**
- * Fractions for rendering a goal bar of fixed length. `fill` is how much of
- * the bar shows the goal color; `over` is how much of the right end turns
- * red once the goal is exceeded. The bar never grows past its full length,
- * so the red portion is scaled to the goal and caps at the whole bar once
- * you're a full goal's worth over (2x the target).
+ * Fractions for rendering a goal bar of fixed length. Until the goal is met
+ * the bar represents the target, so `fill` is worked/target and `over` is 0.
+ * Once the goal is exceeded the full bar represents the accumulated time
+ * instead: `fill` is the goal's share of it and `over` the excess share, so
+ * the two always sum to the whole bar and the overflow only approaches
+ * (never reaches) the full width.
  */
 export const goalBarFractions = (
   worked: number,
   target: number
 ): { fill: number; over: number } => {
   if (target <= 0) return { fill: 0, over: 0 };
-  const fill = Math.min(Math.max(worked, 0) / target, 1);
-  const over = worked > target ? Math.min((worked - target) / target, 1) : 0;
-  return { fill, over };
+  const clamped = Math.max(worked, 0);
+  if (clamped <= target) return { fill: clamped / target, over: 0 };
+  return { fill: target / clamped, over: (clamped - target) / clamped };
 };
 
 export const loadGoals = (): ColorGoal[] => {

--- a/src/lib/taskColors.ts
+++ b/src/lib/taskColors.ts
@@ -18,3 +18,15 @@ export const colorLabel = (hex: string): string => {
   const found = TASK_COLORS.find((c) => c.hex === hex);
   return found ? found.name.charAt(0).toUpperCase() + found.name.slice(1) : hex;
 };
+
+// Darker shade of a #rrggbb color, used for the overflow segment of goal
+// bars. Falls back to the input for anything that isn't a 6-digit hex.
+export const darkenColor = (hex: string, factor = 0.6): string => {
+  const match = /^#([0-9a-f]{6})$/i.exec(hex);
+  if (!match) return hex;
+  const channels = [0, 2, 4].map((i) => {
+    const value = Math.round(parseInt(match[1].slice(i, i + 2), 16) * factor);
+    return Math.min(Math.max(value, 0), 255).toString(16).padStart(2, "0");
+  });
+  return `#${channels.join("")}`;
+};


### PR DESCRIPTION
## Summary
This PR redesigns how goal bar overflow is visualized when work exceeds the target time. Instead of capping the fill at 100% and showing overage as a separate red segment, the bar now represents the total accumulated time once the goal is exceeded, with the goal and overflow shown as proportional shares.

## Key Changes
- **Goal bar logic**: Changed `goalBarFractions()` to use proportional shares of accumulated time when work exceeds the target, rather than capping fill at 1 and scaling overage independently
  - Before goal: `fill = worked/target`, `over = 0`
  - After goal: `fill = target/accumulated`, `over = excess/accumulated`
  - This ensures `fill + over` always equals 1 and overflow asymptotically approaches (never reaches) full width
- **Overflow styling**: Replaced hard-coded red color with `darkenColor()` function that darkens the goal's assigned color by 60% for better visual consistency
- **New utility function**: Added `darkenColor()` to `taskColors.ts` to generate darker hex color variants, with fallback for non-standard hex formats
- **Updated tests**: Revised test cases to reflect the new proportional behavior and verify that fill and over always sum to 1

## Implementation Details
- The `darkenColor()` function parses 6-digit hex colors, scales RGB channels by a factor (default 0.6), and clamps values to valid 0-255 range
- The overflow segment now uses the darkened goal color instead of a generic red, providing better visual hierarchy while maintaining the goal color theme

https://claude.ai/code/session_018F5rfhJSvwEAHYLPYcBHiJ