### PR TITLE
Add dark mode support with theme switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,28 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#ffffff" />
     <title>doro</title>
+    <!-- Apply the saved theme before first paint to avoid a light flash.
+         Mirrors applyTheme in src/hooks/useTheme.ts. -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem("doroTheme");
+          var dark =
+            stored === "dark" ||
+            (stored !== "light" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches);
+          if (dark) {
+            document.documentElement.classList.add("dark");
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute("content", "#0a0a0a");
+          }
+        } catch (e) {
+          /* localStorage unavailable — default to light */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,13 +9,14 @@ import WorkflowyMode from "./components/WorkflowyMode";
 import ColorGoals from "./components/ColorGoals";
 import useTasks from "./hooks/useTasks";
 import useTimer from "./hooks/useTimer";
+import useTheme from "./hooks/useTheme";
 import type Task from "./types/Task";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { formatDuration } from "./lib/formatDuration";
 import { getLiveDuration } from "./lib/getDuration";
-import { Shuffle } from "lucide-react";
+import { Monitor, Moon, Shuffle, Sun } from "lucide-react";
 import { DEFAULT_COLOR, colorLabel } from "./lib/taskColors";
 
 const makeDate = (mins: number) => Date.now() + mins * 60 * 1000;
@@ -119,6 +120,7 @@ function App() {
   }, [shuffleMode]);
   const taskManager = useTasks();
   const { isPaused, countdownRef, ...timer } = useTimer();
+  const { theme, cycleTheme } = useTheme();
 
   // Give the countdown a fresh full duration, optionally starting it once
   // the new date prop has reached the Countdown (its componentDidUpdate
@@ -419,8 +421,27 @@ function App() {
         >
           <Shuffle />
         </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto text-muted-foreground"
+          onClick={(e) => {
+            e.stopPropagation();
+            cycleTheme();
+          }}
+          title={`Theme: ${theme} — click to change`}
+          aria-label={`Theme: ${theme}. Click to change`}
+        >
+          {theme === "light" ? (
+            <Sun />
+          ) : theme === "dark" ? (
+            <Moon />
+          ) : (
+            <Monitor />
+          )}
+        </Button>
         <span
-          className="ml-auto text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+          className="text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
           onClick={(e) => {
             e.stopPropagation();
             if (totalDuration > 0) setIsColorBreakdownOpen(true);
@@ -433,7 +454,9 @@ function App() {
       <h1
         className={cn(
           "text-5xl font-bold py-4 px-6 rounded-lg text-center",
-          isPaused ? "bg-yellow-300 text-yellow-900" : "bg-green-300 text-green-900",
+          isPaused
+            ? "bg-yellow-300 text-yellow-900 dark:bg-yellow-400/20 dark:text-yellow-200"
+            : "bg-green-300 text-green-900 dark:bg-green-400/20 dark:text-green-200",
           pausedLong && "animate-pause-pulse"
         )}
       >

--- a/src/components/ActiveTaskView.tsx
+++ b/src/components/ActiveTaskView.tsx
@@ -195,7 +195,7 @@ function ActiveTaskView({
           if (moved !== null) onNotesChange(task, moved);
         }}
         placeholder="Notes..."
-        className="min-h-[80px] resize-y bg-white"
+        className="min-h-[80px] resize-y bg-white dark:bg-card"
       />
       {(onDone || onDeactivate) && (
         <div className="mt-2 flex gap-2">

--- a/src/components/ColorGoals.tsx
+++ b/src/components/ColorGoals.tsx
@@ -28,24 +28,27 @@ function GoalBar({
       <div className="relative flex-1 h-6 rounded-md bg-muted overflow-hidden">
         <div
           className="absolute inset-y-0 left-0"
-          style={{ width: `${fill * 100}%`, backgroundColor: goal.color }}
+          style={{
+            width: `${fill * 100}%`,
+            backgroundColor: `color-mix(in srgb, ${goal.color} var(--goal-fill-strength, 100%), transparent)`,
+          }}
         />
         {over > 0 && (
           <div
             className="absolute inset-y-0 right-0"
             style={{
               width: `${over * 100}%`,
-              backgroundColor: darkenColor(goal.color),
+              backgroundColor: `color-mix(in srgb, ${darkenColor(goal.color)} var(--goal-fill-strength, 100%), transparent)`,
             }}
             title={`${formatDuration(overMs)} over goal`}
           />
         )}
-        <div className="absolute inset-0 flex items-center justify-between px-2 text-xs font-medium text-gray-900">
+        <div className="absolute inset-0 flex items-center justify-between px-2 text-xs font-medium text-gray-900 dark:text-zinc-100">
           <span>{colorLabel(goal.color)}</span>
           <span>
             {formatDuration(worked)} / {formatDuration(goal.target)}
             {overMs > 0 && (
-              <span className="font-bold text-red-950">
+              <span className="font-bold text-red-950 dark:text-red-300">
                 {" "}
                 +{formatDuration(overMs)}
               </span>

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "doroTheme";
+
+export const loadTheme = (): Theme => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "light" || stored === "dark" ? stored : "system";
+};
+
+const systemPrefersDark = () =>
+  window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+// Keep in sync with the inline script in index.html, which applies the
+// class before first paint to avoid a flash of the wrong theme.
+export const applyTheme = (theme: Theme) => {
+  const dark = theme === "dark" || (theme === "system" && systemPrefersDark());
+  document.documentElement.classList.toggle("dark", dark);
+  // Match the browser chrome (macOS wrapper, PWA title bar) to the app
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", dark ? "#0a0a0a" : "#ffffff");
+};
+
+export default function useTheme() {
+  const [theme, setTheme] = useState<Theme>(loadTheme);
+
+  useEffect(() => {
+    if (theme === "system") {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, theme);
+    }
+    applyTheme(theme);
+  }, [theme]);
+
+  // Follow OS-level changes while in system mode
+  useEffect(() => {
+    if (theme !== "system") return;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme("system");
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, [theme]);
+
+  const cycleTheme = () =>
+    setTheme((t) => (t === "system" ? "light" : t === "light" ? "dark" : "system"));
+
+  return { theme, setTheme, cycleTheme };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -49,7 +49,14 @@ body {
 }
 
 :root {
+  color-scheme: light;
   --radius: 0.625rem;
+  /* Timer banner pulse when paused too long */
+  --pulse-yellow: #fde047;
+  --pulse-red: #f87171;
+  /* Goal bar fills are drawn at full strength in light mode; dark mode
+     dims them (see .dark) so light text stays readable on top */
+  --goal-fill-strength: 100%;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -84,6 +91,10 @@ body {
 }
 
 .dark {
+  color-scheme: dark;
+  --pulse-yellow: color-mix(in srgb, #facc15 20%, transparent);
+  --pulse-red: color-mix(in srgb, #f87171 30%, transparent);
+  --goal-fill-strength: 45%;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -118,8 +129,8 @@ body {
 }
 
 @keyframes pause-pulse {
-  0%, 100% { background-color: #fde047; }
-  50% { background-color: #f87171; }
+  0%, 100% { background-color: var(--pulse-yellow); }
+  50% { background-color: var(--pulse-red); }
 }
 
 .animate-pause-pulse {


### PR DESCRIPTION
## Summary
This PR adds comprehensive dark mode support to the application with a user-friendly theme switcher. Users can now toggle between light, dark, and system (OS-level) theme preferences, with the selection persisted to localStorage and applied before the first paint to avoid visual flashing.

## Key Changes
- **New `useTheme` hook** (`src/hooks/useTheme.ts`): Manages theme state with three options (light/dark/system), persists preference to localStorage, and syncs with OS-level color scheme changes
- **Theme switcher button**: Added to the main UI with icons (Sun/Moon/Monitor) that cycle through theme options
- **Inline script in `index.html`**: Applies saved theme before first paint to prevent flash of wrong theme on page load
- **CSS variables for dark mode**: Updated color scheme variables and added theme-aware pulse animations and goal bar fill strengths
- **Dark mode styling**: Added dark mode classes and color-mix utilities throughout components:
  - Timer banner (yellow/red pulse animations)
  - Goal bars with adjusted fill opacity for readability
  - Text colors in ColorGoals and ActiveTaskView components
  - Meta theme-color tag for browser chrome matching
- **System preference tracking**: Automatically applies theme changes when OS-level color scheme preference changes while in "system" mode

## Implementation Details
- The theme application logic is kept in sync between the inline script (for pre-paint application) and the `applyTheme` function to ensure consistency
- Dark mode uses CSS `color-mix()` for intelligent color blending rather than hardcoded values, making the theme more maintainable
- The `--goal-fill-strength` CSS variable allows goal bar colors to be dimmed in dark mode (45%) while remaining vibrant in light mode (100%) for better text contrast
- Theme preference is removed from localStorage when set to "system" to keep storage clean

https://claude.ai/code/session_01BXBb6rA55aPc4JPWLQi9zq